### PR TITLE
Update default.rb

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -45,7 +45,7 @@ template "#{Chef::Config[:file_cache_path]}/spacewalk-answers.conf" do
 end
 
 execute 'spacewalk-setup' do
-  command "spacewalk-setup --disconnected --answer-file=#{Chef::Config[:file_cache_path]}/spacewalk-answers.conf"
+  command "spacewalk-setup --answer-file=#{Chef::Config[:file_cache_path]}/spacewalk-answers.conf"
   action :run
   creates "/etc/rhn/rhn.conf"
 end


### PR DESCRIPTION
Removed --disconnected option from execute 'spacewak-setup' code block. The latest version of spacewalk did not like this option when trying to install with an imbedded postrgres server.